### PR TITLE
Define "any" step value for "number" fields

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -120,6 +120,7 @@ function FormField(props) {
                 inputProps.type = 'range';
             else
                 inputProps.type = 'number';
+                inputProps.step = 'any'
 
             InputField = FormInput;
 


### PR DESCRIPTION
The `integer` fields have a `step` attribute set to `1`. 
But `number` fields have no `step` attribute set, so in the case where the form is submitted with `<input name="foo" type="number" required />` with a decimal value, html validation prevents submission.

One solution is to define a `noValidate` attribute for the form tag, but we lose the ultimate validation of the form.
Another solution is to define a `step="any"` for `number`s fields.

Ref https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#step