### PR TITLE
Fixed typo at data.js

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -325,7 +325,7 @@ function getSyncedObject(data, schema, getRef) {
             else if (type === 'oneOf')
                 newData[key] = getBlankOneOf(schemaValue, getRef);
             else if (type === 'anyOf')
-                newData[key] = getBlankAntOf(schemaValue, getRef);
+                newData[key] = getBlankAnyOf(schemaValue, getRef);
             else if (type === 'boolean')
                 newData[key] = default_ === false ? false : (default_ || null);
             else if (type === 'integer' || type === 'number')


### PR DESCRIPTION
Hey @bhch 👋 

`django-jsonform` user here. There is a typo in `data.js` that causes models with schemas containing the `anyOf` clause to produce rendering errors in the Django admin.

I found the solution as changing `getBlankAntOf` as `getBlankAnyOf`

Here is the schema that I'm using:

```python
schema = {
    "$defs": {
        "Calendar": {
            "properties": {
                "id": {"title": "Id", "type": "string"},
                "grant_id": {
                    "title": "Grant Id",
                    "type": "string",
                },
                "name": {"title": "Name", "type": "string"},
                "read_only": {
                    "title": "Read Only",
                    "type": "boolean",
                },
                "is_owned_by_user": {
                    "title": "Is Owned By User",
                    "type": "boolean",
                },
                "is_primary": {
                    "title": "Is Primary",
                    "type": "boolean",
                },
                "metadata": {
                    "anyOf": [{"type": "object"}, {"type": "null"}],
                    "default": None,
                    "title": "Metadata",
                },
            },
            "required": ["id", "grant_id", "name", "read_only", "is_owned_by_user", "is_primary"],
            "title": "Calendar",
            "type": "object",
        }
    },
    "properties": {"id": {"title": "Id", "type": "string"}, "calendar": {"$ref": "#/$defs/Calendar"}},
    "required": ["id", "calendar"],
    "title": "CalendarContainer",
    "type": "object",
}
```